### PR TITLE
Open Graph improvements

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,6 +27,7 @@ export const metadata: Metadata = {
     images,
   },
   twitter: {
+    card: 'summary_large_image',
     title,
     description,
     images,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,14 @@ const font = Montserrat({subsets: ['latin']});
 
 const title = 'ADSR';
 const description = 'ADSR - simple synthesizer built with Elementary Audio';
-const images = ['/og-image.png'];
+const images = [
+  {
+    url: '/og-image.png',
+    alt: description,
+    width: 1200,
+    height: 630,
+  },
+];
 
 export const metadata: Metadata = {
   title,


### PR DESCRIPTION
- define OG image size in metadata
- use `summary_large_image` for Twitter (which also makes Discord/Telegram previews larger)