### PR TITLE
Midi input support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "clsx": "2.0.0",
         "next": "13.4.12",
         "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "webmidi": "^3.1.6"
       },
       "devDependencies": {
         "@next/eslint-plugin-next": "13.4.12",
@@ -56,6 +57,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+      "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@elemaudio/core": {
@@ -861,6 +873,12 @@
       "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/@types/webmidi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/webmidi/-/webmidi-2.0.7.tgz",
+      "integrity": "sha512-BMVefNAum/swSmQJdTbRWBuDPeWT7fHAZEzmtY6eBl1ObvkWVzh39VvAFC8v9n7Y5XoOpWmeYzyUUVfmpq3ggQ==",
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.2.1",
@@ -1784,6 +1802,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/djipevents": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/djipevents/-/djipevents-2.0.7.tgz",
+      "integrity": "sha512-KNFYaU85imxOCKOUsIR70Iz9E19r96/X7LSH+u0tSoZdpWcBdzoqtTsU+wuLhc6GMpSFob+KInkZAbfKi01Bjg==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.6"
       }
     },
     "node_modules/dlv": {
@@ -3046,6 +3072,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/jazz-midi": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/jazz-midi/-/jazz-midi-1.7.9.tgz",
+      "integrity": "sha512-c8c4BBgwxdsIr1iVm53nadCrtH7BUlnX3V95ciK/gbvXN/ndE5+POskBalXgqlc/r9p2XUbdLTrgrC6fou5p9w==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.18.2.tgz",
@@ -3102,6 +3137,16 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jzz": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/jzz/-/jzz-1.6.6.tgz",
+      "integrity": "sha512-Swp7o+fCvXUDgL6o9mQ/KsuFPrhppjusLF4xtgNVBP4MGctkNx+2SZ/KoXWV0cEgEAwVZEWAQcXxyIZVpo76mg==",
+      "optional": true,
+      "dependencies": {
+        "@types/webmidi": "^2.0.7",
+        "jazz-midi": "^1.7.9"
       }
     },
     "node_modules/levn": {
@@ -4047,6 +4092,11 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
@@ -4890,6 +4940,20 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webmidi": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/webmidi/-/webmidi-3.1.6.tgz",
+      "integrity": "sha512-IeC7dsm9bupL7Z6PZxVGAbcrguclJ0VAxn3+7UjoZazZWKEwwnq3/ToDbHQdWzOOLwat4fYjp978X1Rd3SQ8Qg==",
+      "dependencies": {
+        "djipevents": "^2.0.7"
+      },
+      "engines": {
+        "node": ">=8.5"
+      },
+      "optionalDependencies": {
+        "jzz": "^1.5.6"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5014,6 +5078,14 @@
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
       "dev": true
+    },
+    "@babel/runtime": {
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+      "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
+      "requires": {
+        "regenerator-runtime": "^0.14.0"
+      }
     },
     "@elemaudio/core": {
       "version": "2.0.1",
@@ -5490,6 +5562,12 @@
       "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true,
       "peer": true
+    },
+    "@types/webmidi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/webmidi/-/webmidi-2.0.7.tgz",
+      "integrity": "sha512-BMVefNAum/swSmQJdTbRWBuDPeWT7fHAZEzmtY6eBl1ObvkWVzh39VvAFC8v9n7Y5XoOpWmeYzyUUVfmpq3ggQ==",
+      "optional": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "6.2.1",
@@ -6107,6 +6185,14 @@
       "peer": true,
       "requires": {
         "path-type": "^4.0.0"
+      }
+    },
+    "djipevents": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/djipevents/-/djipevents-2.0.7.tgz",
+      "integrity": "sha512-KNFYaU85imxOCKOUsIR70Iz9E19r96/X7LSH+u0tSoZdpWcBdzoqtTsU+wuLhc6GMpSFob+KInkZAbfKi01Bjg==",
+      "requires": {
+        "@babel/runtime": "^7.20.6"
       }
     },
     "dlv": {
@@ -7018,6 +7104,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "jazz-midi": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/jazz-midi/-/jazz-midi-1.7.9.tgz",
+      "integrity": "sha512-c8c4BBgwxdsIr1iVm53nadCrtH7BUlnX3V95ciK/gbvXN/ndE5+POskBalXgqlc/r9p2XUbdLTrgrC6fou5p9w==",
+      "optional": true
+    },
     "jiti": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.18.2.tgz",
@@ -7065,6 +7157,16 @@
       "requires": {
         "array-includes": "^3.1.5",
         "object.assign": "^4.1.3"
+      }
+    },
+    "jzz": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/jzz/-/jzz-1.6.6.tgz",
+      "integrity": "sha512-Swp7o+fCvXUDgL6o9mQ/KsuFPrhppjusLF4xtgNVBP4MGctkNx+2SZ/KoXWV0cEgEAwVZEWAQcXxyIZVpo76mg==",
+      "optional": true,
+      "requires": {
+        "@types/webmidi": "^2.0.7",
+        "jazz-midi": "^1.7.9"
       }
     },
     "levn": {
@@ -7661,6 +7763,11 @@
         "picomatch": "^2.2.1"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+    },
     "regexp.prototype.flags": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
@@ -8199,6 +8306,15 @@
       "requires": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
+      }
+    },
+    "webmidi": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/webmidi/-/webmidi-3.1.6.tgz",
+      "integrity": "sha512-IeC7dsm9bupL7Z6PZxVGAbcrguclJ0VAxn3+7UjoZazZWKEwwnq3/ToDbHQdWzOOLwat4fYjp978X1Rd3SQ8Qg==",
+      "requires": {
+        "djipevents": "^2.0.7",
+        "jzz": "^1.5.6"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "clsx": "2.0.0",
     "next": "13.4.12",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "webmidi": "^3.1.6"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "13.4.12",

--- a/src/components/hooks/useStateWithEffect.ts
+++ b/src/components/hooks/useStateWithEffect.ts
@@ -1,0 +1,30 @@
+import {useCallback, useRef, useState} from 'react';
+
+/**
+ * Synchronously call a callback on every state change.
+ *
+ * The callback should be idempotent as it may be called multiple times by React.
+ *
+ * @param initialState
+ * @param callback
+ */
+export const useStateWithEffect = <T extends Record<string, unknown>>(
+  initialState: T,
+  callback: (state: T) => unknown,
+) => {
+  const [state, setState] = useState(0);
+  const stateRef = useRef(initialState);
+
+  const setStateWithEffect = useCallback(
+    (update: Partial<T>) => {
+      // Using a ref here means the setStateWithEffect function remains stable across renders
+      Object.assign(stateRef.current, update);
+      callback(stateRef.current);
+      // But we still want to trigger a re-render and update any UI
+      setState((count) => count + 1);
+    },
+    [callback],
+  );
+
+  return [stateRef.current, setStateWithEffect] as const;
+};

--- a/src/components/pages/SynthPage/MidiSelector.tsx
+++ b/src/components/pages/SynthPage/MidiSelector.tsx
@@ -1,0 +1,81 @@
+import {useEffect, useState} from 'react';
+import {type Input, WebMidi} from 'webmidi';
+
+type MidiSelectorProps = {
+  playNote: (note: number) => void;
+  stopNote: (note: number) => void;
+};
+
+function connect() {
+  WebMidi.enable().catch((err) => {
+    console.error(err);
+  });
+}
+
+export function MidiSelector({playNote, stopNote}: MidiSelectorProps) {
+  const [devices, setDevices] = useState<Input[]>(WebMidi.inputs);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  useEffect(() => {
+    const updateInputs = () => {
+      setDevices([...WebMidi.inputs]);
+    };
+
+    const enabledListener = WebMidi.addListener('enabled', updateInputs);
+    const connectedListener = WebMidi.addListener('connected', updateInputs);
+    const disconnectedListener = WebMidi.addListener(
+      'disconnected',
+      updateInputs,
+    );
+    return () => {
+      if (!Array.isArray(enabledListener)) enabledListener.remove();
+      if (!Array.isArray(connectedListener)) connectedListener.remove();
+      if (!Array.isArray(disconnectedListener)) disconnectedListener.remove();
+    };
+  }, []);
+
+  useEffect(() => {
+    const selectedInput = WebMidi.inputs[selectedIndex];
+    if (selectedInput) {
+      const noteOnListener = selectedInput.addListener('noteon', ({note}) => {
+        playNote(note.number);
+      });
+      const noteOffListener = selectedInput.addListener('noteoff', ({note}) => {
+        stopNote(note.number);
+      });
+
+      return () => {
+        if (!Array.isArray(noteOnListener)) noteOnListener.remove();
+        if (!Array.isArray(noteOffListener)) noteOffListener.remove();
+      };
+    }
+  }, [playNote, selectedIndex, stopNote]);
+
+  if (!WebMidi.enabled) {
+    return (
+      <button type='button' className='bg-gray-4 px-2' onClick={connect}>
+        Enable MIDI
+      </button>
+    );
+  }
+
+  if (!devices.length) {
+    return 'No MIDI devices detected';
+  }
+
+  return (
+    <select
+      value={selectedIndex}
+      className='bg-gray-4 px-2'
+      onChange={(event) => {
+        setSelectedIndex(parseInt(event.target.value, 10));
+      }}
+    >
+      {devices.map((device, index) => (
+        <option key={device.id} value={index}>
+          {device.name}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/components/pages/SynthPage/MidiSelector.tsx
+++ b/src/components/pages/SynthPage/MidiSelector.tsx
@@ -35,7 +35,7 @@ export function MidiSelector({playNote, stopNote}: MidiSelectorProps) {
   }, []);
 
   useEffect(() => {
-    const selectedInput = WebMidi.inputs[selectedIndex];
+    const selectedInput = devices[selectedIndex];
     if (selectedInput) {
       const noteOnListener = selectedInput.addListener('noteon', ({note}) => {
         playNote(note.number);
@@ -49,7 +49,7 @@ export function MidiSelector({playNote, stopNote}: MidiSelectorProps) {
         if (!Array.isArray(noteOffListener)) noteOffListener.remove();
       };
     }
-  }, [playNote, selectedIndex, stopNote]);
+  }, [devices, playNote, selectedIndex, stopNote]);
 
   if (!WebMidi.enabled) {
     return (

--- a/src/components/pages/SynthPage/SynthContainer.tsx
+++ b/src/components/pages/SynthPage/SynthContainer.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 type SynthContainerProps = {
   isActivated?: boolean;
   title: string;
+  titleRight?: React.ReactNode;
   children: React.ReactNode;
   meterLeft: React.ReactNode;
   meterRight: React.ReactNode;
@@ -11,20 +12,24 @@ type SynthContainerProps = {
 export function SynthContainer({
   isActivated = false,
   title,
+  titleRight,
   children,
   meterLeft,
   meterRight,
 }: SynthContainerProps) {
   return (
     <div className='bg-gray-2'>
-      <div className='flex select-none items-center gap-2 bg-gray-1 px-2 py-1 text-sm uppercase'>
-        <div
-          className={clsx(
-            'h-2 w-2 rounded-full',
-            isActivated ? 'bg-green' : 'bg-gray-3',
-          )}
-        />
-        {title}
+      <div className='flex items-center justify-between bg-gray-1 px-2 py-1'>
+        <div className='flex select-none items-center gap-2 text-sm uppercase'>
+          <div
+            className={clsx(
+              'h-2 w-2 rounded-full',
+              isActivated ? 'bg-green' : 'bg-gray-3',
+            )}
+          />
+          {title}
+        </div>
+        <div className='text-xs'> {titleRight}</div>
       </div>
       <div className='flex'>
         <div className='p-2 sm:p-3'>{children}</div>

--- a/src/components/pages/SynthPage/SynthPage.tsx
+++ b/src/components/pages/SynthPage/SynthPage.tsx
@@ -145,8 +145,11 @@ function SynthPageMain({core}: SynthPageMainProps) {
   );
 
   const playNote = useCallback(
-    (midiNote: number) => {
-      setStateAndRender({gate: 1, freq: noteToFreq(midiNote)});
+    (midiNote?: number) => {
+      const stateUpdate = midiNote
+        ? {gate: 1, freq: noteToFreq(midiNote)}
+        : {gate: 1};
+      setStateAndRender(stateUpdate);
     },
     [setStateAndRender],
   );
@@ -166,7 +169,7 @@ function SynthPageMain({core}: SynthPageMainProps) {
       }
 
       if (event.code === keyCodes.space) {
-        playNote(60);
+        playNote();
       }
     };
 
@@ -243,13 +246,13 @@ function SynthPageMain({core}: SynthPageMainProps) {
         icon={<PlayIcon />}
         title="Touch here to play or press the 'Space' key."
         onTouchStart={() => {
-          playNote(60);
+          playNote();
         }}
         onTouchEnd={() => {
           stopNote();
         }}
         onMouseDown={() => {
-          playNote(60);
+          playNote();
         }}
         onMouseUp={() => {
           stopNote();

--- a/src/utils/math/midi.ts
+++ b/src/utils/math/midi.ts
@@ -1,0 +1,4 @@
+export function noteToFreq(note: number) {
+  const a = 440;
+  return (a / 32) * 2 ** ((note - 9) / 12);
+}


### PR DESCRIPTION
Thanks for sharing this code. It's been great as a starting point for my explorations. I'm contributing this code back in the spirit of sharing but I won't be offended if you don't feel it's right for your project.

I started out with a bit of a refactor to remove a lot of the refs and make the state handling more Reacty. But then I realised that rendering the audio in a `useEffect` hook introduces a considerable delay compared to rendering it in the event handler. In my tests one results in a latency of ~5ms and the other 0.5ms. I expect you already know this.

So then I created an unorthodox state management hook which applies the audio graph immediately and then updates the state (which then updates the UI). This means the render phase of the component is not pure (it has the side effect of updating the Elementary Audio graph) but I don't think it will cause problems because the Elementary update is idempotent and can be called multiple times without causing issues.

Finally, I added Web MIDI support so that I can play the synth with an external keyboard. 