### PR TITLE
MIDI to Hz: implementation closer to JUCE

### DIFF
--- a/src/utils/math/midi.ts
+++ b/src/utils/math/midi.ts
@@ -2,6 +2,5 @@
  * Gets frequency in Hz for corresponding MIDI note.
  */
 export function midiNoteToFreq(note: number) {
-  const a = 440;
-  return (a / 32) * 2 ** ((note - 9) / 12);
+  return 440 * 2 ** ((note - 69) / 12);
 }

--- a/src/utils/math/midi.ts
+++ b/src/utils/math/midi.ts
@@ -1,5 +1,8 @@
 /**
  * Gets frequency in Hz for corresponding MIDI note.
+ *
+ * Same as JUCE's `MidiMessage::getMidiNoteInHertz`:
+ * https://github.com/juce-framework/JUCE/blob/master/modules/juce_audio_basics/midi/juce_MidiMessage.cpp#L1037-L1040
  */
 export function midiNoteToFreq(note: number) {
   return 440 * 2 ** ((note - 69) / 12);


### PR DESCRIPTION
Re-implement `midiNoteToFreq` utility function to look closer to JUCE's `MidiMessage::getMidiNoteInHertz`:
 
https://github.com/juce-framework/JUCE/blob/2a27ebcfae7ca7f6eb62b29d5f002ceefdaadbdb/modules/juce_audio_basics/midi/juce_MidiMessage.cpp#L1037-L1040